### PR TITLE
added deep-copy functions tosc_copy_message and tosc_copy_bundle

### DIFF
--- a/tinyosc.c
+++ b/tinyosc.c
@@ -313,3 +313,26 @@ void tosc_printMessage(tosc_message *osc) {
   }
   printf("\n");
 }
+
+int tosc_copy_message(tosc_message *dst, tosc_message *src)
+{
+  if (dst->len < src->len) {
+    return 0;
+  } // checking space is enough
+  memcpy(dst->buffer, src->buffer, src->len);
+  dst->len = src->len;
+  dst->marker = dst->buffer + (src->marker - src->buffer);
+  dst->format = dst->buffer + (src->format - src->buffer);
+  return 1;
+}
+
+int tosc_copy_bundle(tosc_bundle *dst, tosc_bundle *src)
+{
+  if (dst->bufLen < src->bundleLen) {
+    return 0;
+  } // checking space is enough
+  memcpy(dst->buffer, src->buffer, src->bundleLen);
+  dst->bundleLen = src->bundleLen;
+  dst->marker = dst->buffer + (src->marker - src->buffer);
+  return 1;
+}

--- a/tinyosc.h
+++ b/tinyosc.h
@@ -165,6 +165,18 @@ void tosc_printOscBuffer(char *buffer, const int len);
  */
 void tosc_printMessage(tosc_message *o);
 
+/**
+ * A convenience function to deep-copy an OSC message
+ * The destination message's buffer must have been allocated by the caller.
+ */
+int tosc_copy_message(tosc_message *dst, tosc_message *src);
+
+/**
+ * A convenience function to deep-copy an OSC message
+ * The destination bundle's buffer must have been allocated by the caller.
+ */
+int tosc_copy_bundle(tosc_bundle *dst, tosc_bundle *src);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Added two simple deep copy functions. 

As you can see the memory allocation is completely in charge of the caller (as warned within the function comments), which results in the functions being very simple, which I guess might make them quite light to maintain in the future. 

Anyways please feel absolutely free to close if you don't find them useful in the API. 
(I can move this feature in the client)

Please also feel free to return any feedback or demand for any change or modify it.

Cheers again  👍