### PR TITLE
added continuous Travis-CI, building with checking with both GCC and Clang

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: c
+compiler:
+  - clang
+  - gcc
+script:
+  - . build.sh

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/neonsoftware/tinyosc.svg?branch=ci)](https://travis-ci.org/neonsoftware/tinyosc)
+
 # TinyOSC
 
 TinyOSC is a minimal [Open Sound Control](http://opensoundcontrol.org/) (OSC) library written in C. The typical use case is to parse a raw buffer received directly from a socket. Given the limited nature of the library it also tends to be quite fast. It doesn't hold on to much state and it doesn't do much error checking. If you have a good idea of what OSC packets you will receive and need to process them quickly, this library might be for you.

--- a/tinyosc.c
+++ b/tinyosc.c
@@ -18,6 +18,7 @@
 #include <stdarg.h>
 #include <string.h>
 #include <stdio.h>
+#include <inttypes.h>
 #if _WIN32
 #include <winsock2.h>
 #define tosc_strncpy(_dst, _src, _len) strncpy_s(_dst, _len, _src, _TRUNCATE)
@@ -301,8 +302,8 @@ void tosc_printMessage(tosc_message *osc) {
       case 'f': printf(" %g", tosc_getNextFloat(osc)); break;
       case 'd': printf(" %g", tosc_getNextDouble(osc)); break;
       case 'i': printf(" %d", tosc_getNextInt32(osc)); break;
-      case 'h': printf(" %lld", tosc_getNextInt64(osc)); break;
-      case 't': printf(" %lld", tosc_getNextTimetag(osc)); break;
+      case 'h': printf(" %" PRId64, tosc_getNextInt64(osc)); break;  // PRId64 chooses corrent format (ld,lld,..)
+      case 't': printf(" %" PRIu64, tosc_getNextTimetag(osc)); break; // PRIu64 chooses corrent format (lu,llu,..)
       case 's': printf(" %s", tosc_getNextString(osc)); break;
       case 'F': printf(" false"); break;
       case 'I': printf(" inf"); break;


### PR DESCRIPTION
Hi @mhroth, 

- added .travis.yml, very minimal setup. Just running ``build.sh``
- if it's the first Travis build for your account I'm glad to help in any ways setting it up
- the .travis.yml actually creates 2 jobs, one where GCC is installed, and one whith Clang
- added the build continuous badge [![Build Status](https://travis-ci.org/neonsoftware/tinyosc.svg?branch=ci)](https://travis-ci.org/neonsoftware/tinyosc) in README (it points to by branch's results, will need to be updated, of course )

I additionally had to add the use of numeric macros to print intX_t uintX_t on the various architectures on commit https://github.com/neonsoftware/tinyosc/commit/46537caa6783fcf286c9292aca028400aba1c2cb, as old compilers throw actually an error on the use of lld. 
I love that -Werror is used so I guess it was an occasion for a further improvement towards portability.
Info on the these macros here [here](http://stackoverflow.com/questions/12120426/how-to-print-uint32-t-and-uint16-t-variables-value) and [here](http://en.cppreference.com/w/c/types/integer).
 
Please let me know your opinion on any aspect, and again please feel free to demand for any change or modify it.

Cheers 👍 