### PR TITLE
expose tosc_vwrite

### DIFF
--- a/tinyosc.c
+++ b/tinyosc.c
@@ -15,7 +15,6 @@
  */
 
 #include <stddef.h>
-#include <stdarg.h>
 #include <string.h>
 #include <stdio.h>
 #if _WIN32
@@ -173,7 +172,7 @@ void tosc_writeBundle(tosc_bundle *b, uint64_t timetag, char *buffer, const int 
 }
 
 // always writes a multiple of 4 bytes
-static uint32_t tosc_vwrite(char *buffer, const int len,
+uint32_t tosc_vwrite(char *buffer, const int len,
     const char *address, const char *format, va_list ap) {
   memset(buffer, 0, len); // clear the buffer
   uint32_t i = (uint32_t) strlen(address);

--- a/tinyosc.h
+++ b/tinyosc.h
@@ -19,6 +19,7 @@
 
 #include <stdbool.h>
 #include <stdint.h>
+#include <stdarg.h>
 
 #define TINYOSC_TIMETAG_IMMEDIATELY 1L
 
@@ -159,6 +160,12 @@ uint32_t tosc_getBundleLength(tosc_bundle *b);
  */
 uint32_t tosc_writeMessage(char *buffer, const int len, const char *address,
     const char *fmt, ...);
+
+/**
+ * Like tosc_writeMessage, but allows passing in a va_list directly.
+ */
+uint32_t tosc_vwrite(char *buffer, const int len,
+    const char *address, const char *format, va_list ap);
 
 /**
  * A convenience function to (non-destructively) print a buffer containing


### PR DESCRIPTION
this can be useful for wrapping the writing method; e.g. like this:


    void send(const char *addr, const char *fmt, ...) {
      static uint8_t tx_buf[256];

      va_list args;
      va_start(args, fmt);

      size_t len = tosc_vwrite(
        tx_buf, sizeof(tx_buf),
        addr, fmt, args
      );

      va_end(args);

      slip_send(tx_buf, len);
    }