### PR TITLE
Fix bug in tosc_reset

### DIFF
--- a/tinyosc.c
+++ b/tinyosc.c
@@ -155,10 +155,10 @@ unsigned char *tosc_getNextMidi(tosc_message *o) {
 }
 
 tosc_message *tosc_reset(tosc_message *o) {
-  int i = 0;
-  while (o->format[i] != '\0') ++i;
+  int i = o->format - o->buffer;
+  while (o->buffer[i] != '\0') ++i;
   i = (i + 4) & ~0x3; // advance to the next multiple of 4 after trailing '\0'
-  o->marker = o->format + i - 1; // -1 to account for ',' format prefix
+  o->marker = o->buffer + i;
   return o;
 }
 


### PR DESCRIPTION
tosc_reset was operating on offsets based on the location of the format (o->format).  When it came time to adjust the marker location to a multiple of 4 bytes it adjusted that index to a multiple of 4 bytes, which gives you a location aligned relative to o->format.  But the location needs aligned relative to the entire buffer.

This change re-writes tosc_reset to operate entirely relative to the buffer start rather than to the start of the format.