### PR TITLE
Add Windows support

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,14 @@
 #!/bin/bash
 
-if type "clang" > /dev/null 2>&1; then
-  clang *.c -Werror -O0 -g -o tinyosc
+# Check if the script is being run on Windows
+if [[ "$OSTYPE" == "msys" || "$OSTYPE" == "win32" ]]; then
+  LIBS="-lWs2_32"
 else
-  gcc *.c -Werror -std=c99 -O0 -g -o tinyosc
+  LIBS=""
+fi
+
+if type "clang" > /dev/null 2>&1; then
+  clang *.c -Werror -O0 -g -o tinyosc $LIBS
+else
+  gcc *.c -Werror -std=c99 -O0 -g -o tinyosc $LIBS
 fi

--- a/tinyosc.c
+++ b/tinyosc.c
@@ -21,6 +21,7 @@
 #if _WIN32
 #include <Winsock2.h>
 #define tosc_strncpy(_dst, _src, _len) strncpy_s(_dst, _len, _src, _TRUNCATE)
+#ifndef htonll
 unsigned long long htonll(unsigned long long val) {
   //little endian check
   if(htonl(1) == 1) {
@@ -29,6 +30,8 @@ unsigned long long htonll(unsigned long long val) {
     return ((unsigned long long)htonl((unsigned int)(val & 0xFFFFFFFF)) << 32) | htonl((unsigned int)(val >> 32));
   }
 }
+#endif
+#ifndef ntohll
 unsigned long long ntohll(unsigned long long val) {
   //little endian check
   if(ntohl(1) == 1) {
@@ -37,6 +40,7 @@ unsigned long long ntohll(unsigned long long val) {
     return ((unsigned long long)ntohl((unsigned int)(val & 0xFFFFFFFF)) << 32) | ntohl((unsigned int)(val >> 32));
   }
 }
+#endif
 #else
 #include <netinet/in.h>
 #define tosc_strncpy(_dst, _src, _len) strncpy(_dst, _src, _len)

--- a/tinyosc.c
+++ b/tinyosc.c
@@ -21,26 +21,6 @@
 #if _WIN32
 #include <Winsock2.h>
 #define tosc_strncpy(_dst, _src, _len) strncpy_s(_dst, _len, _src, _TRUNCATE)
-#ifndef htonll
-unsigned long long htonll(unsigned long long val) {
-  //little endian check
-  if(htonl(1) == 1) {
-    return val;
-  } else {
-    return ((unsigned long long)htonl((unsigned int)(val & 0xFFFFFFFF)) << 32) | htonl((unsigned int)(val >> 32));
-  }
-}
-#endif
-#ifndef ntohll
-unsigned long long ntohll(unsigned long long val) {
-  //little endian check
-  if(ntohl(1) == 1) {
-    return val;
-  } else {
-    return ((unsigned long long)ntohl((unsigned int)(val & 0xFFFFFFFF)) << 32) | ntohl((unsigned int)(val >> 32));
-  }
-}
-#endif
 #else
 #include <netinet/in.h>
 #define tosc_strncpy(_dst, _src, _len) strncpy(_dst, _src, _len)

--- a/tinyosc.c
+++ b/tinyosc.c
@@ -19,8 +19,24 @@
 #include <string.h>
 #include <stdio.h>
 #if _WIN32
-#include <winsock2.h>
+#include <Winsock2.h>
 #define tosc_strncpy(_dst, _src, _len) strncpy_s(_dst, _len, _src, _TRUNCATE)
+unsigned long long htonll(unsigned long long val) {
+  //little endian check
+  if(htonl(1) == 1) {
+    return val;
+  } else {
+    return ((unsigned long long)htonl((unsigned int)(val & 0xFFFFFFFF)) << 32) | htonl((unsigned int)(val >> 32));
+  }
+}
+unsigned long long ntohll(unsigned long long val) {
+  //little endian check
+  if(ntohl(1) == 1) {
+    return val;
+  } else {
+    return ((unsigned long long)ntohl((unsigned int)(val & 0xFFFFFFFF)) << 32) | ntohl((unsigned int)(val >> 32));
+  }
+}
 #else
 #include <netinet/in.h>
 #define tosc_strncpy(_dst, _src, _len) strncpy(_dst, _src, _len)


### PR DESCRIPTION
Added some basic changes to get this to compile for Windows. Defines `htonll` and `ntohll` if they're not defined (ie: MSYS2 using GCC)