### PR TITLE
platform-specific specifiers from <inttypes.h>

### DIFF
--- a/tinyosc.c
+++ b/tinyosc.c
@@ -18,6 +18,7 @@
 #include <stdarg.h>
 #include <string.h>
 #include <stdio.h>
+#include <inttypes.h>
 #if _WIN32
 #include <winsock2.h>
 #define tosc_strncpy(_dst, _src, _len) strncpy_s(_dst, _len, _src, _TRUNCATE)
@@ -309,8 +310,8 @@ void tosc_printMessage(tosc_message *osc) {
       case 'f': printf(" %g", tosc_getNextFloat(osc)); break;
       case 'd': printf(" %g", tosc_getNextDouble(osc)); break;
       case 'i': printf(" %d", tosc_getNextInt32(osc)); break;
-      case 'h': printf(" %lld", tosc_getNextInt64(osc)); break;
-      case 't': printf(" %lld", tosc_getNextTimetag(osc)); break;
+      case 'h': printf(" %" PRId64, tosc_getNextInt64(osc)); break;
+      case 't': printf(" %" PRIu64, tosc_getNextTimetag(osc)); break;
       case 's': printf(" %s", tosc_getNextString(osc)); break;
       case 'F': printf(" false"); break;
       case 'I': printf(" inf"); break;


### PR DESCRIPTION
int64_t and uint64_t have platform-specific underlying types,  the portable way to print them is to use the PRId64 and PRIu64 macros from <inttypes.h>